### PR TITLE
Charts 8294 entry list add checking permissions for workbooks entry

### DIFF
--- a/src/db/models/favorite/index.ts
+++ b/src/db/models/favorite/index.ts
@@ -180,7 +180,10 @@ class Favorite extends Model {
                 );
                 workbookEntries.forEach((entry) => {
                     if (entry?.workbookId && workbookIds.includes(entry.workbookId)) {
-                        result.push(entry);
+                        result.push({
+                            ...entry,
+                            isLocked: false,
+                        });
                     }
                 });
             } else {
@@ -188,6 +191,7 @@ class Favorite extends Model {
                     ...result,
                     workbookEntries.map((entry) => ({
                         ...entry,
+                        isLocked: false,
                         ...(includePermissionsInfo && {
                             permissions: {
                                 execute: true,

--- a/src/db/models/navigation/index.ts
+++ b/src/db/models/navigation/index.ts
@@ -231,12 +231,8 @@ class Navigation extends Model {
             }
         }
 
-        const {onlyPublic, embeddingInfo} = ctx.get('info');
-        const isEmbedding = Boolean(embeddingInfo);
-        const checkWorkbookEnabled = !onlyPublic && !isEmbedding;
-
         if (workbookEntries.length > 0) {
-            if (ctx.config.accessServiceEnabled && checkWorkbookEnabled) {
+            if (!isPrivateRoute && ctx.config.accessServiceEnabled) {
                 const workbookList = await getWorkbooksListByIds(
                     {ctx},
                     {
@@ -248,7 +244,10 @@ class Navigation extends Model {
                 );
                 workbookEntries.forEach((entry) => {
                     if (entry?.workbookId && workbookIds.includes(entry.workbookId)) {
-                        result.push(entry);
+                        result.push({
+                            ...entry,
+                            isLocked: false,
+                        });
                     }
                 });
             } else {
@@ -256,6 +255,7 @@ class Navigation extends Model {
                     ...result,
                     workbookEntries.map((entry) => ({
                         ...entry,
+                        isLocked: false,
                         ...(includePermissionsInfo && {
                             permissions: {
                                 execute: true,

--- a/src/services/new/collection/get-collection-breadcrumbs.ts
+++ b/src/services/new/collection/get-collection-breadcrumbs.ts
@@ -41,7 +41,7 @@ export const getCollectionBreadcrumbs = async (
 
     const targetTrx = getReplica(trx);
 
-    const breadcrumbs = await getParents({ctx, trx: targetTrx, collectionId});
+    const breadcrumbs = await getParents({ctx, trx: targetTrx, collectionIds: [collectionId]});
 
     if (breadcrumbs.length === 0) {
         throw new AppError(US_ERRORS.COLLECTION_NOT_EXISTS, {

--- a/src/services/new/workbook/get-workbooks-list-by-ids.ts
+++ b/src/services/new/workbook/get-workbooks-list-by-ids.ts
@@ -1,0 +1,188 @@
+import {WorkbookModel, WorkbookModelColumn} from '../../../db/models/new/workbook';
+import {makeSchemaValidator} from '../../../components/validation-schema-compiler';
+import {ServiceArgs} from '../types';
+import {getReplica} from '../utils';
+import {logInfo} from '../../../utils';
+import {registry} from '../../../registry';
+
+import {WorkbookPermission} from '../../../entities/workbook';
+
+import {Feature, isEnabledFeature} from '../../../components/features';
+
+const validateArgs = makeSchemaValidator({
+    type: 'object',
+    required: ['workbookIds'],
+    properties: {
+        workbookId: {
+            type: ['array', 'string'],
+        },
+    },
+});
+
+type GetWorkbooksListAndAllParentsArgs = {
+    workbookIds: Nullable<string>[];
+};
+
+export const getWorkbooksListByIds = async (
+    {
+        ctx,
+        trx,
+        skipValidation = false,
+    }: // skipCheckPermissions = false
+    ServiceArgs,
+    args: GetWorkbooksListAndAllParentsArgs,
+): Promise<WorkbookModel[]> => {
+    const {workbookIds} = args;
+
+    logInfo(ctx, 'GET WORKBOOKS LIST AND ALL PARENTS START', {
+        workbookIds,
+    });
+
+    const {
+        tenantId,
+        // isPrivateRoute
+    } = ctx.get('info');
+
+    if (!skipValidation) {
+        validateArgs(args);
+    }
+
+    const targetTrx = getReplica(trx);
+
+    // const recursiveName = 'collectionParents';
+
+    const workbookList = await WorkbookModel.query(targetTrx)
+        .where({
+            [WorkbookModelColumn.DeletedAt]: null,
+            [WorkbookModelColumn.TenantId]: tenantId,
+        })
+        .whereIn([WorkbookModelColumn.WorkbookId], workbookIds);
+
+    const {Workbook} = registry.common.classes.get();
+
+    // const {accessServiceEnabled} = ctx.config;
+
+    const collectionIds: Nullable<string>[] | [] = workbookList
+        .map((workbook) => workbook.collectionId)
+        .filter((item) => Boolean(item));
+
+    const parents = await getParentsByIds({
+        ctx,
+        trx: targetTrx,
+        collectionIds,
+    });
+
+    const workbooksMap = new Map<WorkbookModel, string[]>();
+
+    const result: WorkbookModel[] = [];
+
+    workbookList.forEach(async (model) => {
+        const collectionId =
+            parents.find((item) => item.collectionId === model.collectionId)?.collectionId || null;
+
+        const map: {[key: string]: string | null} = {};
+
+        parents.forEach((parent: CollectionModel) => {
+            map[parent.collectionId] = parent.parentId;
+        });
+
+        const parentsforWorkbook = getParentsIds(collectionId, map);
+
+        workbooksMap.set(model, parentsforWorkbook);
+    });
+
+    for await (const pair of workbooksMap) {
+        const [workbookModel, parentIds] = pair;
+
+        const workbook = new Workbook({
+            ctx,
+            model: workbookModel,
+        });
+
+        try {
+            await workbook.checkPermission({
+                parentIds,
+                permission: isEnabledFeature(ctx, Feature.UseLimitedView)
+                    ? WorkbookPermission.LimitedView
+                    : WorkbookPermission.View,
+            });
+
+            result.push(workbookModel);
+        } catch (e) {
+            console.log('eene: ', e);
+        }
+    }
+
+    return result;
+};
+
+import {TransactionOrKnex} from 'objection';
+import {AppContext} from '@gravity-ui/nodekit';
+
+import {CollectionModel, CollectionModelColumn} from '../../../db/models/new/collection';
+
+interface GetParentsArgs {
+    ctx: AppContext;
+    trx?: TransactionOrKnex;
+    collectionIds: Nullable<string>[];
+}
+
+export const getParentsByIds = async ({ctx, trx, collectionIds}: GetParentsArgs) => {
+    const {tenantId, projectId} = ctx.get('info');
+
+    const targetTrx = getReplica(trx);
+
+    const recursiveName = 'collectionParents';
+
+    const result = await CollectionModel.query(targetTrx)
+        .withRecursive(recursiveName, (qb1) => {
+            qb1.select()
+                .from(CollectionModel.tableName)
+                .where({
+                    [CollectionModelColumn.TenantId]: tenantId,
+                    [CollectionModelColumn.ProjectId]: projectId,
+                    [CollectionModelColumn.DeletedAt]: null,
+                })
+                .whereIn([CollectionModelColumn.CollectionId], collectionIds)
+                .union((qb2) => {
+                    qb2.select(`${CollectionModel.tableName}.*`)
+                        .from(CollectionModel.tableName)
+                        .where({
+                            [`${CollectionModel.tableName}.${CollectionModelColumn.TenantId}`]:
+                                tenantId,
+                            [`${CollectionModel.tableName}.${CollectionModelColumn.ProjectId}`]:
+                                projectId,
+                            [`${CollectionModel.tableName}.${CollectionModelColumn.DeletedAt}`]:
+                                null,
+                        })
+                        .join(
+                            recursiveName,
+                            `${recursiveName}.${CollectionModelColumn.ParentId}`,
+                            `${CollectionModel.tableName}.${CollectionModelColumn.CollectionId}`,
+                        );
+                });
+        })
+        .select()
+        .from(recursiveName)
+        .timeout(CollectionModel.DEFAULT_QUERY_TIMEOUT);
+
+    return result;
+};
+
+export const getParentsIds = (
+    collectionId: string | null,
+    map: {[key: string]: string | null},
+): string[] => {
+    let id: string | null = collectionId;
+    const arr: string[] = id ? [id] : [];
+
+    while (id !== null) {
+        const curr: string | null = map[id];
+
+        if (curr !== null) arr.push(curr);
+
+        id = curr;
+    }
+
+    return arr;
+};

--- a/src/services/new/workbook/get-workbooks-list.ts
+++ b/src/services/new/workbook/get-workbooks-list.ts
@@ -106,7 +106,7 @@ export const getWorkbooksList = async (
         parents = await getParents({
             ctx,
             trx: targetTrx,
-            collectionId,
+            collectionIds: [collectionId],
         });
 
         if (parents.length === 0) {

--- a/src/types/models/tables-columns.ts
+++ b/src/types/models/tables-columns.ts
@@ -82,6 +82,7 @@ export interface LinksColumns {
 }
 
 export interface FavoriteColumns {
+    workbookId: string | null;
     entryId: string;
     tenantId: string;
     login: string;


### PR DESCRIPTION
I implemented a new feature that can help check access rights for entities that are in the workbook, a recursive SQL request was added to get all the parents of the workbook by the ID list, as well as the division of entities into those that are in the workbook and those that are in the workbook