### PR TITLE
Added index for fk to states, locks

### DIFF
--- a/src/db/migrations/20231222084058_add_locks_states_fk_indexes.ts
+++ b/src/db/migrations/20231222084058_add_locks_states_fk_indexes.ts
@@ -1,0 +1,17 @@
+import type {Knex} from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+    return knex.raw(`
+        CREATE INDEX states_entry_id_idx ON states(entry_id);
+
+        CREATE INDEX locks_entry_id_idx ON locks(entry_id);
+    `);
+}
+
+export async function down(knex: Knex): Promise<void> {
+    return knex.raw(`
+        DROP INDEX locks_entry_id_idx;
+
+        DROP INDEX states_entry_id_idx;
+    `);
+}


### PR DESCRIPTION
Added index for foreign key entry_id to tables `states`, `locks`. 
This will improve cascade deletion by tenant_id from the table tenants.