### PR TITLE
Fix "Connection terminated unexpectedly" from knex

### DIFF
--- a/src/db/init-db.ts
+++ b/src/db/init-db.ts
@@ -27,7 +27,7 @@ function convertCamelCase(dataObj = {}) {
 export const getKnexOptions = () => ({
     client: 'pg',
     pool: {
-        min: 5,
+        min: 0,
         max: 15,
         acquireTimeoutMillis: 40000,
         createTimeoutMillis: 50000,


### PR DESCRIPTION
Related to the [issue](https://github.com/knex/knex/issues/3523). 

The "postgresql driver" (knex and tarn) creates a pool of connections to the database. If min is set to a value other than zero, the driver makes some of the connections long-lived. The problem is that the driver does not track the situation that the connection is dead and still makes a request to it as a result, gets an error and dies. If you set min to 0 as advised in the issue, everything will work. 

The official knex [documentation](https://knexjs.org/guide/#pool) also advises to set pool.min to 0.
`
Note that the default value of min is 2 only for historical reasons. It can result in problems with stale connections, despite tarn's default idle connection timeout of 30 seconds, which is only applied when there are more than min active connections. It is recommended to set min: 0 so all idle connections can be terminated.
`