### PR TITLE
Fix deletion of workbooks when deleting a collection

### DIFF
--- a/src/services/new/collection/delete-collection.ts
+++ b/src/services/new/collection/delete-collection.ts
@@ -109,18 +109,6 @@ export const deleteCollection = async (
 
         const collectionsForDeleteIds = collectionsForDelete.map((item) => item.collectionId);
 
-        const deletedCollections = await CollectionModel.query(transactionTrx)
-            .patch({
-                [CollectionModelColumn.DeletedBy]: userId,
-                [CollectionModelColumn.DeletedAt]: raw(CURRENT_TIMESTAMP),
-            })
-            .where(CollectionModelColumn.CollectionId, 'in', collectionsForDeleteIds)
-            .where({
-                [CollectionModelColumn.DeletedAt]: null,
-            })
-            .returning('*')
-            .timeout(CollectionModel.DEFAULT_QUERY_TIMEOUT);
-
         const workbooksForDelete = await WorkbookModel.query(transactionTrx)
             .select()
             .where(WorkbookModelColumn.CollectionId, 'in', collectionsForDeleteIds)
@@ -148,6 +136,18 @@ export const deleteCollection = async (
                 );
             }),
         );
+
+        const deletedCollections = await CollectionModel.query(transactionTrx)
+            .patch({
+                [CollectionModelColumn.DeletedBy]: userId,
+                [CollectionModelColumn.DeletedAt]: raw(CURRENT_TIMESTAMP),
+            })
+            .where(CollectionModelColumn.CollectionId, 'in', collectionsForDeleteIds)
+            .where({
+                [CollectionModelColumn.DeletedAt]: null,
+            })
+            .returning('*')
+            .timeout(CollectionModel.DEFAULT_QUERY_TIMEOUT);
 
         return deletedCollections;
     });


### PR DESCRIPTION
Previously workbooks deletion applies after deletion of collection. It seems incorrect especially when the user has access for collection, but doesn't have access to specific workbook inside.

It seems that workbook deletion should occur before the collection deletion