### PR TITLE
Truncate table instead of running migrations on int tests

### DIFF
--- a/jest/int/helpers/index.js
+++ b/jest/int/helpers/index.js
@@ -1,0 +1,7 @@
+const tableExists = require('./table-exists');
+const truncateTables = require('./truncate-tables');
+
+module.exports = {
+    tableExists,
+    truncateTables,
+};

--- a/jest/int/helpers/table-exists.js
+++ b/jest/int/helpers/table-exists.js
@@ -1,0 +1,14 @@
+module.exports = async (knex, table = 'migrations') => {
+    const result = await knex.raw(
+        `
+            SELECT EXISTS (
+                SELECT FROM information_schema.tables
+                WHERE table_schema = 'public'
+                AND table_name = ?
+            );
+        `,
+        [table],
+    );
+
+    return result.rows[0].exists;
+};

--- a/jest/int/helpers/truncate-tables.js
+++ b/jest/int/helpers/truncate-tables.js
@@ -1,0 +1,14 @@
+module.exports = async function truncateTables(knex, exclude = ['migrations', 'migrations_lock']) {
+    const tables = await knex
+        .select('table_name')
+        .from('information_schema.tables')
+        .where({
+            table_schema: 'public',
+            table_type: 'BASE TABLE',
+        })
+        .whereNotIn('table_name', exclude);
+
+    for (const table of tables) {
+        await knex.raw(`TRUNCATE TABLE "${table.tableName}" RESTART IDENTITY CASCADE`);
+    }
+};

--- a/src/tests/int/seeds/initial-data.ts
+++ b/src/tests/int/seeds/initial-data.ts
@@ -1,0 +1,15 @@
+import type {Knex} from 'knex';
+
+import {testTenantId} from '../auth';
+
+export const seed = async (knex: Knex) => {
+    await knex('tenants')
+        .insert({
+            tenantId: testTenantId,
+            meta: {},
+            enabled: true,
+            createdAt: '2021-09-01 18:00:00.00000+03',
+        })
+        .onConflict('tenantId')
+        .merge();
+};


### PR DESCRIPTION
Improve int tests benchmark.
Comparing to [this job](https://github.com/datalens-tech/datalens-us/pull/245/checks) (38.135s) the run decreased to 28.794s

