### PR TITLE
Index entries by display_key field

### DIFF
--- a/src/db/migrations/20250304081357_entries_index_by_display_key.ts
+++ b/src/db/migrations/20250304081357_entries_index_by_display_key.ts
@@ -1,0 +1,17 @@
+import type {Knex} from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+    return knex.raw(`
+        CREATE INDEX CONCURRENTLY entries_display_key_idx ON entries USING BTREE(display_key text_pattern_ops);
+    `);
+}
+
+export async function down(knex: Knex): Promise<void> {
+    return knex.raw(`
+        DROP INDEX CONCURRENTLY entries_display_key_idx;
+    `);
+}
+
+export const config = {
+    transaction: false,
+};


### PR DESCRIPTION
Currently we have index of `key` field, but not `display_key`. But we have a lot of queries with condition `display_key LIKE "folder/%". 
Despite `key` field have GIN index, I've decided to create BTREE(text_pattern_ops) INDEX as found GIN index more heavy and redundant.