### PR TITLE
Split sql request for getRelationGraph to  fix freezing during migration

### DIFF
--- a/src/const/common.ts
+++ b/src/const/common.ts
@@ -67,7 +67,6 @@ export const RETURN_RELATION_COLUMNS = [
     'type',
     'display_key as key',
     'meta',
-    'depth',
     'tenantId',
     'public',
     'workbookId',

--- a/src/services/entry/actions/get-related-entries.ts
+++ b/src/services/entry/actions/get-related-entries.ts
@@ -82,7 +82,9 @@ export async function getRelatedEntries(
         .select([{entryId: endToStart ? 'toId' : 'fromId'}, 'depth'])
         .from('relatedEntries');
 
-    const relatedEntryIds = await relatedEntryIdsQuery;
+    const relatedEntryIds = await relatedEntryIdsQuery.timeout(
+        extendedTimeout ? EXTENDED_QUERY_TIMEOUT : DEFAULT_QUERY_TIMEOUT,
+    );
 
     const depthMap = new Map<string, number>();
     for (const row of relatedEntryIds as unknown as {entryId: string; depth: number}[]) {
@@ -102,7 +104,6 @@ export async function getRelatedEntries(
 
     const relatedEntriesQuery = Entry.query(getReplica(trx))
         .select([...RETURN_RELATION_COLUMNS, 'entries.created_at'])
-        .from('entries')
         .join('revisions', 'entries.savedId', 'revisions.revId')
         .whereIn('entries.entryId', entryIdList)
         .orderBy('entries.createdAt');


### PR DESCRIPTION
Split request into two separate queries to prevent freezing on large datasets.