### PR TITLE
Add index to entries table by created_by field

### DIFF
--- a/src/db/migrations/20250325121617_entry-index-created-by.ts
+++ b/src/db/migrations/20250325121617_entry-index-created-by.ts
@@ -1,0 +1,17 @@
+import type {Knex} from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+    return knex.raw(`
+        CREATE INDEX CONCURRENTLY entries_created_by_idx ON entries USING btree(created_by);
+    `);
+}
+
+export async function down(knex: Knex): Promise<void> {
+    return knex.raw(`
+        DROP INDEX CONCURRENTLY entries_created_by_idx;
+    `);
+}
+
+export const config = {
+    transaction: false,
+};

--- a/src/db/migrations/20250328101417_entry-index-by-folder-scope.ts
+++ b/src/db/migrations/20250328101417_entry-index-by-folder-scope.ts
@@ -1,0 +1,17 @@
+import type {Knex} from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+    return knex.raw(`
+        CREATE INDEX CONCURRENTLY tenant_id_folder_scope_idx ON entries(tenant_id, (CASE WHEN scope = 'folder' THEN 0 ELSE 1 END));
+    `);
+}
+
+export async function down(knex: Knex): Promise<void> {
+    return knex.raw(`
+        DROP INDEX CONCURRENTLY tenant_id_folder_scope_idx;
+    `);
+}
+
+export const config = {
+    transaction: false,
+};


### PR DESCRIPTION
**Overview:**
This pull request adds two new indices to enhance query performance:

1. **`entries_created_by_idx`** - Optimizes the retrieval of entries created by the current user.
2. **`tenant_id_folder_scope_idx`** - Improves performance for listing entries at the `/v1/entries` endpoint.

**Rationale:**
These indices are designed to boost read efficiency without requiring changes to the existing codebase or database schema.

**Alternative Considered:**
An alternative approach was to create a `parent_path` field, generated similarly to the `name` field, and add an index on `tenant_id` + `parent_path`. This would allow replacing the current `LIKE /path/_% AND NOT LIKE /path/_%/_%` queries with more efficient searches that leverage `Index Scan` instead of `Parallel Bitmap Heap Scan`. However, this option necessitates changes to both the schema and the codebase, which could introduce unnecessary complexity.

