### PR TITLE
Change getEntries params

### DIFF
--- a/src/db/models/navigation/index.ts
+++ b/src/db/models/navigation/index.ts
@@ -142,7 +142,7 @@ class Navigation extends Model {
             )
             .where({
                 isDeleted: false,
-                scope,
+                ...(scope ? {scope} : {}),
                 'entries.tenantId': tenantId,
             })
             .where((builder) => {

--- a/src/db/models/navigation/scheme.ts
+++ b/src/db/models/navigation/scheme.ts
@@ -7,7 +7,7 @@ import {
 
 export const validateGetEntries = compileSchema({
     type: 'object',
-    required: ['tenantId', 'scope'],
+    required: ['tenantId'],
     properties: {
         tenantId: {
             type: 'string',
@@ -74,6 +74,14 @@ export const validateGetEntries = compileSchema({
             type: 'boolean',
         },
     },
+    anyOf: [
+        {
+            required: ['scope'],
+        },
+        {
+            required: ['ids'],
+        },
+    ],
 });
 
 export const validateInterTenantGetEntries = compileSchema({

--- a/src/types/models/navigation.ts
+++ b/src/types/models/navigation.ts
@@ -12,7 +12,7 @@ export interface PaginationEntriesResponse {
 export interface GetEntriesConfig extends BasicRequestParams {
     tenantId: string;
     ids?: string | string[];
-    scope: EntryScope;
+    scope?: EntryScope;
     type?: string;
     orderBy?: EntriesOrderByFilter;
     createdBy?: string | string[];

--- a/src/types/services.types.ts
+++ b/src/types/services.types.ts
@@ -54,7 +54,7 @@ export interface ResolveTenantIdByEntryId extends StdServiceParams {
 }
 
 interface NavigationServiceParams extends StdServiceParams {
-    scope: EntryScope;
+    scope?: EntryScope;
     page?: number;
     pageSize?: number;
 }
@@ -73,6 +73,7 @@ export interface GetEntries extends NavigationServiceParams {
     excludeLocked?: boolean;
 }
 export interface InterTenantGetEntries extends NavigationServiceParams {
+    scope: EntryScope;
     ids?: string | string[];
     type?: string;
     orderBy?: OrderByDirection;


### PR DESCRIPTION
Now `getEntries` has a required `scope` param and optional `ids`, but in some cases we need to get entries by id without specifying a scope.