### PR TITLE
Add migrations: collection_id to entries

### DIFF
--- a/src/db/migrations/20250812115716_add_collection_id_column_to_entries.ts
+++ b/src/db/migrations/20250812115716_add_collection_id_column_to_entries.ts
@@ -1,0 +1,13 @@
+import type {Knex} from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+    return knex.raw(`
+        ALTER TABLE entries ADD COLUMN collection_id BIGINT;
+    `);
+}
+
+export async function down(knex: Knex): Promise<void> {
+    return knex.raw(`
+        ALTER TABLE entries DROP COLUMN collection_id;
+    `);
+}

--- a/src/db/migrations/20250812115720_add_collection_index_to_entries.ts
+++ b/src/db/migrations/20250812115720_add_collection_index_to_entries.ts
@@ -1,0 +1,17 @@
+import type {Knex} from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+    return knex.raw(`
+        CREATE INDEX CONCURRENTLY entries_collection_id_idx ON entries USING BTREE (collection_id);
+    `);
+}
+
+export async function down(knex: Knex): Promise<void> {
+    return knex.raw(`
+        DROP INDEX CONCURRENTLY entries_collection_id_idx;
+    `);
+}
+
+export const config = {
+    transaction: false,
+};

--- a/src/db/migrations/20250812115722_add_collection_foreign_key_containts_to_entries.ts
+++ b/src/db/migrations/20250812115722_add_collection_foreign_key_containts_to_entries.ts
@@ -1,0 +1,15 @@
+import type {Knex} from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+    return knex.raw(`
+        ALTER TABLE entries
+            ADD CONSTRAINT entries_collection_id_ref FOREIGN KEY (collection_id)
+                REFERENCES collections(collection_id) ON DELETE CASCADE NOT VALID;
+    `);
+}
+
+export async function down(knex: Knex): Promise<void> {
+    return knex.raw(`
+        ALTER TABLE entries DROP CONSTRAINT entries_collection_id_ref;
+    `);
+}

--- a/src/db/migrations/20250812115725_validate_entries_collection_id_foreign_key.ts
+++ b/src/db/migrations/20250812115725_validate_entries_collection_id_foreign_key.ts
@@ -1,0 +1,11 @@
+import type {Knex} from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+    return knex.raw(`
+        ALTER TABLE entries VALIDATE CONSTRAINT entries_collection_id_ref;
+    `);
+}
+
+export async function down(): Promise<void> {
+    return;
+}

--- a/src/db/migrations/20250812121502_add_entries_single_container_constraint.ts
+++ b/src/db/migrations/20250812121502_add_entries_single_container_constraint.ts
@@ -1,0 +1,15 @@
+import type {Knex} from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+    return knex.raw(`
+        ALTER TABLE entries
+            ADD CONSTRAINT entries_single_container_constraint 
+            CHECK (NOT (workbook_id IS NOT NULL AND collection_id IS NOT NULL)) NOT VALID;
+    `);
+}
+
+export async function down(knex: Knex): Promise<void> {
+    return knex.raw(`
+        ALTER TABLE entries DROP CONSTRAINT entries_single_container_constraint;
+    `);
+}

--- a/src/db/migrations/20250812121506_validate_entries_single_container_constraint.ts
+++ b/src/db/migrations/20250812121506_validate_entries_single_container_constraint.ts
@@ -1,0 +1,11 @@
+import type {Knex} from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+    return knex.raw(`
+        ALTER TABLE entries VALIDATE CONSTRAINT entries_single_container_constraint;
+    `);
+}
+
+export async function down(): Promise<void> {
+    return;
+}

--- a/src/db/migrations/20250812121516_add_entries_uniq_scope_name_collection_id_index.ts
+++ b/src/db/migrations/20250812121516_add_entries_uniq_scope_name_collection_id_index.ts
@@ -1,0 +1,18 @@
+import type {Knex} from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+    return knex.raw(`
+        CREATE UNIQUE INDEX CONCURRENTLY entries_uniq_scope_name_conllection_id_idx
+            ON entries (scope, name, collection_id);
+    `);
+}
+
+export async function down(knex: Knex): Promise<void> {
+    return knex.raw(`
+        DROP INDEX CONCURRENTLY entries_uniq_scope_name_conllection_id_idx;
+    `);
+}
+
+export const config = {
+    transaction: false,
+};


### PR DESCRIPTION
1) Added `collection_id` column to the entries table

2) Added `entries_single_container_constraint` with NOT VALID option to avoid ACCESS EXCLUSIVE locks
This prevents table-wide locking during constraint addition

3) Created `entries_uniq_scope_name_collection_id_idx` as a unique index instead of using UNIQUE CONSTRAINT like before with `uniq_scope_name_workbook_id`.